### PR TITLE
Add SQL Test Stages With Python

### DIFF
--- a/Pipeline/ExecuteSQLScript.yml
+++ b/Pipeline/ExecuteSQLScript.yml
@@ -33,6 +33,10 @@ stages:
       subscriptionId: $(subscriptionID)
       applicationName: sql-automation
 
+  - template: Templates/test-sql-script-stage.yml
+    parameters:
+      environmentName: dev
+
   - template: Templates/execute-sql-script-stage.yml
     parameters:
       variableGroups: 
@@ -53,6 +57,10 @@ stages:
       resourceGroupName: 'sql-automation-tst'
       subscriptionId: $(subscriptionID)
       applicationName: sql-automation
+
+  - template: Templates/test-sql-script-stage.yml
+    parameters:
+      environmentName: tst  
 
   - template: templates/execute-sql-script-stage.yml
     parameters:

--- a/Pipeline/Templates/execute-sql-script-stage.yml
+++ b/Pipeline/Templates/execute-sql-script-stage.yml
@@ -1,19 +1,19 @@
 parameters:
-- name: serviceConnection
-  type: string
-- name: resourceEnvironmentName
-  type: string  
-- name: variableGroups
-  type: object
-- name: environmentName
-  type: string
+  - name: serviceConnection
+    type: string
+  - name: resourceEnvironmentName
+    type: string  
+  - name: variableGroups
+    type: object
+  - name: environmentName
+    type: string
 
 stages:
   - stage: RollbackSQLScriptIn${{ parameters.environmentName }}
     displayName: Execute Script - ${{ parameters.environmentName }}
     variables:
       - '${{ each variableGroup in parameters.variableGroups }}':
-        - group: '${{variableGroup}}' 
+        - group: '${{variableGroup}}'
     jobs:
       - job: RollbackSQLScript
         displayName: 'Rollback SQL Script'
@@ -23,11 +23,11 @@ stages:
           - task: AzureCLI@2
             displayName: 'Rollback SQL Script'
             inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
+              azureSubscription: ${{ parameters.serviceConnection }}
               scriptType: 'pscore'
               scriptLocation: 'ScriptPath'
-              ScriptPath: ./Script-Execution-Pipeline-Project/PowerShell/ExecuteSQLScript.ps1
-              ScriptArguments: '-mode rollback -sqlServerFQDN $(sqlServerFQDN) -sqlServerName "$(sqlServerName)-admin-password" -sqlServerAdminUserName $(sqlServerAdminUserName) -sqlDbName $(sqlDbName) -keyVaultName $(keyVaultName) -ScriptFolder "$(ScriptFolder)" -ScriptName "$(ScriptName)"'     
+              scriptPath: ./Script-Execution-Pipeline-Project/PowerShell/ExecuteSQLScript.ps1
+              scriptArguments: '-mode rollback -sqlServerFQDN $(sqlServerFQDN) -sqlServerName "$(sqlServerName)-admin-password" -sqlServerAdminUserName $(sqlServerAdminUserName) -sqlDbName $(sqlDbName) -keyVaultName $(keyVaultName) -ScriptFolder "$(ScriptFolder)" -ScriptName "$(ScriptName)"'     
               azurePowerShellVersion: 'LatestVersion'
               failOnStandardError: true
 
@@ -36,11 +36,11 @@ stages:
         pool: server
         dependsOn: RollbackSQLScript
         steps:
-        - task: ManualValidation@0
-          timeoutInMinutes: 60
-          inputs:
-            instructions: 'Please validate rollback was successful before continuing.'
-            onTimeout: 'reject'        
+          - task: ManualValidation@0
+            timeoutInMinutes: 60
+            inputs:
+              instructions: 'Please validate rollback was successful before continuing.'
+              onTimeout: 'reject'        
 
       - job: commitSQLScriptIn${{ parameters.environmentName }}
         displayName: 'Commit SQL Script'
@@ -53,10 +53,10 @@ stages:
           - task: AzureCLI@2
             displayName: 'Commit SQL Script'
             inputs:
-              azureSubscription: ${{parameters.serviceConnection}}
-              ScriptType: 'pscore'
+              azureSubscription: ${{ parameters.serviceConnection }}
+              scriptType: 'pscore'
               scriptLocation: 'ScriptPath'
-              ScriptPath: ./Script-Execution-Pipeline-Project/PowerShell/ExecuteSQLScript.ps1
-              ScriptArguments: '-mode commit -InstrumentationKey $(InstrumentationKey) -sqlServerFQDN $(sqlServerFQDN) -sqlServerName "$(sqlServerName)-admin-password" -sqlServerAdminUserName $(sqlServerAdminUserName) -sqlDbName $(sqlDbName) -keyVaultName $(keyVaultName) -ScriptFolder "$(ScriptFolder)" -ScriptName "$(ScriptName)" -queuedBy "$(Build.QueuedBy)"'
+              scriptPath: ./Script-Execution-Pipeline-Project/PowerShell/ExecuteSQLScript.ps1
+              scriptArguments: '-mode commit -InstrumentationKey $(InstrumentationKey) -sqlServerFQDN $(sqlServerFQDN) -sqlServerName "$(sqlServerName)-admin-password" -sqlServerAdminUserName $(sqlServerAdminUserName) -sqlDbName $(sqlDbName) -keyVaultName $(keyVaultName) -ScriptFolder "$(ScriptFolder)" -ScriptName "$(ScriptName)" -queuedBy "$(Build.QueuedBy)"'
               azurePowerShellVersion: 'LatestVersion'
               failOnStandardError: true

--- a/Pipeline/Templates/test-sql-script-stage.yml
+++ b/Pipeline/Templates/test-sql-script-stage.yml
@@ -1,0 +1,55 @@
+parameters:
+  - name: environmentName
+    type: string  
+
+stages:
+  - stage: TestSQLScriptIn${{ parameters.environmentName }}
+    displayName: Test Script - ${{ parameters.environmentName }}
+    jobs:
+      - job: TestSQLScript
+        displayName: 'Test SQL Script'
+        steps:
+          - checkout: self
+          - checkout: database-scripts
+
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.11'
+              addToPath: true
+
+          - script: |
+              python -m pip install --upgrade pip
+              pip install sqlparse
+            displayName: 'Install dependencies'
+
+          - task: CopyFiles@2
+            displayName: 'Copy Python script to artifact staging directory'
+            inputs:
+              contents: 'Script-Execution-Pipeline-Project/Python/testSqlScript.py'
+              targetFolder: '$(build.artifactstagingdirectory)/publish'
+              flattenFolders: true
+              overWrite: true
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish Artifact'
+            inputs:
+              PathtoPublish: '$(build.artifactstagingdirectory)/publish'
+              ArtifactName: 'pythondrop'
+              publishLocation: 'Container'
+
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              buildType: 'current'
+              downloadType: 'single'
+              artifactName: 'pythondrop'
+              downloadPath: '$(System.ArtifactsDirectory)'
+
+          # Diagnostic step to list files after downloading artifacts
+          - script: ls $(System.ArtifactsDirectory)/pythondrop
+            displayName: 'List files after downloading artifacts'
+          - script: ls -R
+            displayName: "List all files in directory"
+
+          # Run the SQL validation script with correct path to SQL file
+          - script: python $(System.ArtifactsDirectory)/pythondrop/testSqlScript.py --sql_script "./database-scripts/$(ScriptFolder)/$(ScriptName)"
+            displayName: 'Run SQL validation script'

--- a/Python/testSqlScript.py
+++ b/Python/testSqlScript.py
@@ -1,0 +1,45 @@
+import sqlparse
+import argparse
+import os
+
+# Create the parser
+parser = argparse.ArgumentParser(description="Validate SQL script")
+
+# Add the arguments
+parser.add_argument('--sql_script', type=str, required=True, help='The SQL script file path to be validated')
+
+# Parse the arguments
+args = parser.parse_args()
+
+# Function to check if the parsed SQL is a DDL or DML statement
+def is_ddl_or_dml(parsed):
+    for statement in parsed:
+        if statement.get_type() not in ['UNKNOWN', '']:
+            return True
+    return False
+
+# Read the SQL script content
+if not os.path.isfile(args.sql_script):
+    print(f"Error: The file '{args.sql_script}' was not found.")
+    exit(1)
+
+try:
+    with open(args.sql_script, 'r') as file:
+        sql_script_content = file.read()
+        print(f"Validating SQL script located at: {args.sql_script}")
+        print(f"Script Content:\n{sql_script_content}\n")
+except Exception as e:
+    print(f"Error reading file '{args.sql_script}': {e}")
+    exit(1)
+
+# Parse the SQL script
+try:
+    parsed = sqlparse.parse(sql_script_content)
+    if is_ddl_or_dml(parsed):
+        print("The SQL script is a DDL or DML statement.")
+    else:
+        print("The SQL script is not a DDL or DML statement.")
+        exit(1)
+except Exception as e:
+    print(f"Unexpected error during parsing: {e}")
+    exit(1)


### PR DESCRIPTION
This PR adds new stages to the pipeline that will test the functionality of the SQL scripts before any attempts are made to run them against a database. A python file which contains the validating is published to an artifact through the pipeline, that is then used to run against whatever SQL script is currently configured to be executed through the pipeline.