### PR TITLE
Add pre-prod environment support to pipeline

### DIFF
--- a/Pipeline/ExecuteSQLScript.yml
+++ b/Pipeline/ExecuteSQLScript.yml
@@ -69,3 +69,28 @@ stages:
       environmentName: tst
       serviceConnection: $(devServiceConnection)
       resourceEnvironmentName: t01
+
+####### PRE-PROD #######
+
+  - template: Templates/infrastructure-stage.yml
+    parameters:
+      stageName: DeployInfrastructurePreProd
+      environmentName: ppd
+      EnvironmentId: p02
+      serviceConnection: $(devServiceConnection)
+      location: 'uksouth'
+      resourceGroupName: 'sql-automation-ppd'
+      subscriptionId: $(subscriptionID)
+      applicationName: sql-automation
+
+  - template: Templates/test-sql-script-stage.yml
+    parameters:
+      environmentName: ppd
+
+  - template: templates/execute-sql-script-stage.yml
+    parameters:
+      variableGroups: 
+        - platform-tst-sql-automation
+      environmentName: ppd
+      serviceConnection: $(devServiceConnection)
+      resourceEnvironmentName: p02


### PR DESCRIPTION
This PR updates the pipeline to add support for the pre-production environment. By reusing the stage templates, it enables the pipeline to deploy the infrastructure, test and then execute the SQL scripts.