### PR TITLE
Add condition to ensure manual approval is only in pre-prod

### DIFF
--- a/Pipeline/Templates/execute-sql-script-stage.yml
+++ b/Pipeline/Templates/execute-sql-script-stage.yml
@@ -35,6 +35,7 @@ stages:
         displayName: Manual Approval
         pool: server
         dependsOn: RollbackSQLScript
+        condition: eq('${{ parameters.environmentName }}', 'ppd')
         steps:
           - task: ManualValidation@0
             timeoutInMinutes: 60
@@ -44,7 +45,7 @@ stages:
 
       - job: commitSQLScriptIn${{ parameters.environmentName }}
         displayName: 'Commit SQL Script'
-        dependsOn: waitForValidation
+        dependsOn: RollbackSQLScript
         pool:
           vmImage: 'ubuntu-latest'
         steps:


### PR DESCRIPTION
Small change to ensure the manual approval is only triggered in pre-prod. This does not need to be active in the lower environmnets.