### PR TITLE
Add condition to ensure commit job only runs if rollback successful

### DIFF
--- a/Pipeline/Templates/execute-sql-script-stage.yml
+++ b/Pipeline/Templates/execute-sql-script-stage.yml
@@ -46,7 +46,7 @@ stages:
       - job: commitSQLScriptIn${{ parameters.environmentName }}
         displayName: 'Commit SQL Script'
         dependsOn: waitForValidation
-        condition: in(dependencies.waitForValidation.result, 'Succeeded', 'Skipped')
+        condition: and(in(dependencies.waitForValidation.result, 'Succeeded', 'Skipped'), eq(dependencies.RollbackSQLScript.result, 'Succeeded'))
         pool:
           vmImage: 'ubuntu-latest'
         steps:


### PR DESCRIPTION
This PR introduces more logic to the commit SQL script job to ensure that it only runs if both the validation is skipped or successful, and the rollback job was successful. Without adding this, previous runs would still run the commit stage if the rollback stage failed.