### PR TITLE
Fix PPD Variable Group Name in Pipeline

### DIFF
--- a/Pipeline/ExecuteSQLScript.yml
+++ b/Pipeline/ExecuteSQLScript.yml
@@ -84,7 +84,7 @@ stages:
   - template: templates/execute-sql-script-stage.yml
     parameters:
       variableGroups: 
-        - platform-tst-sql-automation
+        - platform-ppd-sql-automation
       environmentName: ppd
       serviceConnection: $(devServiceConnection)
       resourceEnvironmentName: p02


### PR DESCRIPTION
This hotfix ensures the correct variable group is consumed by the pipeline in the pre-production stages.